### PR TITLE
Fnp 49: Forum routing

### DIFF
--- a/packages/client/src/pages/ForumPage/ForumPage.tsx
+++ b/packages/client/src/pages/ForumPage/ForumPage.tsx
@@ -1,0 +1,33 @@
+import { Link, LoaderFunction, useLoaderData } from 'react-router-dom';
+import { TopicsType } from './ForumPage.types';
+
+// Simulating a request to the server
+export const topicsLoader: LoaderFunction = async (): Promise<TopicsType[]> => {
+  return [
+    {
+      name: 'Announcement',
+      id: 1,
+      commentCount: 10,
+    },
+    {
+      name: 'Complaints',
+      id: 2,
+      commentCount: 0,
+    },
+  ];
+};
+export const ForumPage = () => {
+  const topics = useLoaderData() as TopicsType[];
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {topics.map(topic => (
+        <>
+          <Link to={`/forum/${topic.id}${topic.commentCount ? '/1' : ''}`}>
+            {topic.name}
+          </Link>
+        </>
+      ))}
+    </div>
+  );
+};

--- a/packages/client/src/pages/ForumPage/ForumPage.types.ts
+++ b/packages/client/src/pages/ForumPage/ForumPage.types.ts
@@ -1,0 +1,5 @@
+export type TopicsType = {
+  id: number;
+  name: string;
+  commentCount: number;
+};

--- a/packages/client/src/pages/ForumPage/index.ts
+++ b/packages/client/src/pages/ForumPage/index.ts
@@ -1,0 +1,1 @@
+export * from './ForumPage';

--- a/packages/client/src/pages/ForumTopicPage/ForumTopicPage.tsx
+++ b/packages/client/src/pages/ForumTopicPage/ForumTopicPage.tsx
@@ -1,0 +1,50 @@
+import { LoaderFunction, useLoaderData, useParams } from 'react-router-dom';
+import { CommentType, TopicType } from './ForumTopicPage.types';
+
+// Simulating a request to the server
+export const topicInfo: LoaderFunction = async ({
+  params,
+}): Promise<TopicType> => {
+  return {
+    id: 1,
+    name: 'Announcement',
+    text: `Info about topic ${params.topicId} `,
+    // It's temporary logic, just to remove comments for 'Complaints' page
+    ...(params.topicId === '1' && {
+      comments: [
+        {
+          id: 1,
+          author: 'Ivan',
+          text: 'Hello!',
+        },
+      ],
+    }),
+  };
+};
+
+export const ForumTopicPage = () => {
+  const topicInfo = useLoaderData() as TopicType;
+  const { topicId, page } = useParams();
+
+  return (
+    <div>
+      <h1>Topic Page {topicId}</h1>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <p> {topicInfo.text}</p>
+        {topicInfo?.comments?.map((comment: CommentType) => {
+          return (
+            <div
+              style={{
+                width: '300px',
+                height: '100px',
+                border: '1px solid black',
+              }}>
+              <h2>{comment.author}</h2>
+              <p>{comment.text}</p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/client/src/pages/ForumTopicPage/ForumTopicPage.types.ts
+++ b/packages/client/src/pages/ForumTopicPage/ForumTopicPage.types.ts
@@ -1,0 +1,8 @@
+export type CommentType = { id: number; author: string; text: string };
+
+export type TopicType = {
+  id: number;
+  name: string;
+  text: string;
+  comments?: CommentType[];
+};

--- a/packages/client/src/pages/ForumTopicPage/index.ts
+++ b/packages/client/src/pages/ForumTopicPage/index.ts
@@ -1,0 +1,1 @@
+export * from './ForumTopicPage';

--- a/packages/client/src/pages/index.ts
+++ b/packages/client/src/pages/index.ts
@@ -11,3 +11,5 @@ export * from './GamePage';
 export * from './ProfilePage';
 export * from './GamePausePage';
 export * from './ErrorBoundaryPage';
+export * from './ForumPage';
+export * from './ForumTopicPage';

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, RouteObject } from 'react-router-dom';
 
 import {
   ErrorPage404,
@@ -13,9 +13,13 @@ import {
   SignInPage,
   SignUpPage,
   ErrorBoundaryPage,
+  ForumPage,
+  topicsLoader,
+  ForumTopicPage,
+  topicInfo,
 } from './pages';
 
-const routes = [
+const routes: RouteObject[] = [
   {
     path: '/',
     element: <SignInPage />,
@@ -75,6 +79,18 @@ const routes = [
     path: '/error-boundary',
     element: <ErrorBoundaryPage />,
     errorElement: <ErrorPage404 />,
+  },
+  {
+    path: '/forum',
+    element: <ForumPage />,
+    errorElement: <ErrorPage404 />,
+    loader: topicsLoader,
+  },
+  {
+    path: 'forum/:topicId/:page?',
+    element: <ForumTopicPage />,
+    errorElement: <ErrorPage404 />,
+    loader: topicInfo,
   },
 ];
 


### PR DESCRIPTION
### Какую задачу решаем
Добавление роутинга для форума

### Скриншоты/видяшка (если есть)
На странице форума отображаются два тестовых топика
<img width="530" alt="Снимок экрана 2024-07-31 в 15 04 37" src="https://github.com/user-attachments/assets/816d5e26-03bf-4b60-b2a6-2a58fe44cd3c">

При клике на которые, мы попадаем на сам топик с описанием и комментами(если они есть)
<img width="456" alt="Снимок экрана 2024-07-31 в 15 04 52" src="https://github.com/user-attachments/assets/bd78c59e-315e-4006-a8dc-54390246571b">
<img width="371" alt="Снимок экрана 2024-07-31 в 15 05 03" src="https://github.com/user-attachments/assets/0193fa1b-cf23-40a4-a7aa-af0013d27d27">


